### PR TITLE
adding clipboard and file sharing to qemu

### DIFF
--- a/prov_packer/customization.sh
+++ b/prov_packer/customization.sh
@@ -22,6 +22,11 @@ function wanted_packages() {
   packages=(
     # normally installed with ubuntu
     'software-properties-common'
+    ## from: https://github.com/wimpysworld/quickemu/tree/c0f03e6c9c146af569d3fd1309d2c9887d702b1f#ubuntu-guest
+    # used to enable clipboard support (QEMU)
+    'spice-vdagent'
+    # used to enable file sharing (QEMU)
+    'spice-webdavd'
   )
 
   apt-get install -y "${packages[@]}"


### PR DESCRIPTION
Saw these packages in [another project](https://github.com/wimpysworld/quickemu/tree/c0f03e6c9c146af569d3fd1309d2c9887d702b1f#ubuntu-guest), and figured I could add it here. (heard about other project while listening to [this podcast](https://linuxunplugged.com/427).